### PR TITLE
Fix FTS5 query escaping, fields option validation, and Packagist package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "yetisearch/yetisearch",
+    "name": "yetidevworks/yetisearch",
     "description": "A powerful, pure-PHP search engine library with advanced features",
     "type": "library",
     "license": "MIT",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4da0d23babfda52b3747bc4b7e5e50fd",
+    "content-hash": "0a9c1f24cac6250f5253ff694cf83351",
     "packages": [
         {
             "name": "psr/log",

--- a/src/Index/Indexer.php
+++ b/src/Index/Indexer.php
@@ -6,6 +6,7 @@ use YetiSearch\Contracts\IndexerInterface;
 use YetiSearch\Contracts\StorageInterface;
 use YetiSearch\Contracts\AnalyzerInterface;
 use YetiSearch\Exceptions\IndexException;
+use YetiSearch\Exceptions\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -46,10 +47,93 @@ class Indexer implements IndexerInterface
             'chunk_overlap' => 100
         ], $config);
 
+        $this->config['fields'] = $this->normalizeFieldsConfig($this->config['fields']);
+
         $this->batchSize = $this->config['batch_size'];
         $this->logger = $logger ?? new NullLogger();
 
         $this->ensureIndexExists();
+    }
+
+    /**
+     * Normalize the "fields" option into its canonical associative form.
+     *
+     * The documented form maps a field name to its config:
+     *
+     *     ['title' => ['boost' => 3.0], 'sku' => ['boost' => 1.0]]
+     *
+     * A flat list of field names is accepted as shorthand and expanded to the
+     * default boost:
+     *
+     *     ['title', 'sku']
+     *
+     * The two forms may be mixed. Previously the flat form was accepted without
+     * complaint and then read as if it were associative, so the integer list
+     * keys became the FTS column names and the index was silently built wrong.
+     *
+     * @param mixed $fields
+     * @return array<string, array<string, mixed>>
+     * @throws InvalidArgumentException If the option is not one of the forms above
+     */
+    private function normalizeFieldsConfig($fields): array
+    {
+        if (!is_array($fields)) {
+            throw new InvalidArgumentException(
+                "Indexer option 'fields' must be an array, " . gettype($fields) . ' given'
+            );
+        }
+
+        $normalized = [];
+
+        foreach ($fields as $key => $value) {
+            if (is_int($key)) {
+                // Shorthand: a flat list of field names.
+                if (!is_string($value)) {
+                    throw new InvalidArgumentException(
+                        "Indexer option 'fields' contains a non-string field name at position {$key}: "
+                        . gettype($value) . ' given. Use a list of field names, or a map of field name '
+                        . 'to config such as [\'title\' => [\'boost\' => 3.0]].'
+                    );
+                }
+
+                $name = $this->validateFieldName($value);
+                $normalized[$name] = ['boost' => 1.0];
+                continue;
+            }
+
+            $name = $this->validateFieldName((string)$key);
+
+            if (!is_array($value)) {
+                throw new InvalidArgumentException(
+                    "Indexer option 'fields' entry '{$name}' must be an array of settings, "
+                    . gettype($value) . ' given. Use [\'' . $name . '\' => [\'boost\' => 1.0]], '
+                    . 'or list the field name on its own to take the defaults.'
+                );
+            }
+
+            $normalized[$name] = $value;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Field names become FTS5 column names, so they must be plain SQL identifiers.
+     *
+     * @throws InvalidArgumentException If the name is not a usable identifier
+     */
+    private function validateFieldName(string $name): string
+    {
+        $name = trim($name);
+
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $name)) {
+            throw new InvalidArgumentException(
+                "Invalid field name '{$name}' in indexer option 'fields': "
+                . 'must match /^[a-zA-Z_][a-zA-Z0-9_]*$/'
+            );
+        }
+
+        return $name;
     }
 
     public function insert($documents): void

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -375,20 +375,70 @@ class SearchEngine implements SearchEngineInterface
         $this->indexedTermsCacheTime = 0;
     }
 
+    /**
+     * FTS5 keywords that must be quoted when they appear as a user term,
+     * otherwise the MATCH parser reads them as operators.
+     */
+    private const FTS_KEYWORDS = ['AND', 'OR', 'NOT', 'NEAR'];
+
+    /**
+     * Escape a single user term so it is safe to hand to an FTS5 MATCH expression.
+     *
+     * Only bare alphanumeric terms are legal unquoted in the MATCH grammar.
+     * Anything else — a hyphen in an order number or SKU, a colon, an asterisk,
+     * a quote, a parenthesis — is an operator there and would either change the
+     * meaning of the query or make SQLite reject it outright (a hyphen, for
+     * instance, is read as a column filter, so "BENCH-100821" fails with
+     * "no such column: 100821"). Such terms are wrapped in double quotes, which
+     * makes FTS5 treat them as a literal phrase and re-tokenize them with the
+     * table's own tokenizer.
+     *
+     * This deliberately escapes individual terms only. The operators that
+     * processQuery() builds around them (OR, NEAR(), phrase grouping) are added
+     * outside this method and stay intact.
+     *
+     * @param bool $inPhrase True when the token is being placed inside a
+     *                       double-quoted phrase assembled by the caller.
+     */
     private function escapeFtsToken(string $token, bool $inPhrase = false): string
     {
-        // FTS5 handles apostrophes differently in phrases vs bare terms
         if ($inPhrase) {
-            // In phrases, double the apostrophes
-            return str_replace("'", "''", $token);
-        } else {
-            // For bare terms, if it contains an apostrophe, wrap it in quotes
-            if (strpos($token, "'") !== false) {
-                $escaped = str_replace("'", "''", $token);
-                return '"' . $escaped . '"';
-            }
-            return $token;
+            // The caller wraps the whole phrase in double quotes, so the quote
+            // character is the only one that can break out of it. FTS5 escapes
+            // it by doubling.
+            return str_replace('"', '""', $token);
         }
+
+        // A trailing asterisk is the prefix operator added by prefix_last_token.
+        // Keep it outside the quotes so it stays an operator instead of becoming
+        // a literal character in the phrase.
+        $suffix = '';
+        if (substr($token, -1) === '*') {
+            $token = substr($token, 0, -1);
+            $suffix = '*';
+        }
+
+        if ($token === '') {
+            return '';
+        }
+
+        if ($this->isBareFtsTerm($token)) {
+            return $token . $suffix;
+        }
+
+        return '"' . str_replace('"', '""', $token) . '"' . $suffix;
+    }
+
+    /**
+     * True when a term can be passed to FTS5 MATCH without quoting.
+     */
+    private function isBareFtsTerm(string $token): bool
+    {
+        if (in_array(strtoupper($token), self::FTS_KEYWORDS, true)) {
+            return false;
+        }
+
+        return (bool)preg_match('/^[\p{L}\p{N}]+$/u', $token);
     }
 
     private function processQuery(SearchQuery $query): SearchQuery

--- a/tests/Integration/Indexer/FieldsConfigNormalizationTest.php
+++ b/tests/Integration/Indexer/FieldsConfigNormalizationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace YetiSearch\Tests\Integration\Indexer;
+
+use YetiSearch\Exceptions\InvalidArgumentException;
+use YetiSearch\Tests\TestCase;
+
+/**
+ * The documented shape of the indexer's "fields" option is an associative map
+ * of field name to per-field config. A flat list of field names is a natural
+ * shorthand that used to be accepted silently and then corrupt the index, so it
+ * is now normalized; anything else is rejected loudly.
+ */
+class FieldsConfigNormalizationTest extends TestCase
+{
+    private function ftsColumns(\YetiSearch\YetiSearch $search, string $index): array
+    {
+        $ref = new \ReflectionClass($search);
+        $method = $ref->getMethod('getStorage');
+        $method->setAccessible(true);
+        $storage = $method->invoke($search);
+
+        $storageRef = new \ReflectionClass($storage);
+        $columns = $storageRef->getMethod('getFtsColumns');
+        $columns->setAccessible(true);
+
+        return $columns->invoke($storage, $index);
+    }
+
+    public function test_flat_field_list_produces_the_same_columns_as_the_assoc_form(): void
+    {
+        $flatSearch = $this->createSearchInstance();
+        $flatSearch->createIndex('idx_fields_flat', ['fields' => ['title', 'sku']]);
+        $this->createdIndexes[] = 'idx_fields_flat';
+        $flatColumns = $this->ftsColumns($flatSearch, 'idx_fields_flat');
+
+        $assocSearch = $this->createSearchInstance();
+        $assocSearch->createIndex('idx_fields_assoc', [
+            'fields' => [
+                'title' => ['boost' => 1.0],
+                'sku' => ['boost' => 1.0],
+            ],
+        ]);
+        $this->createdIndexes[] = 'idx_fields_assoc';
+        $assocColumns = $this->ftsColumns($assocSearch, 'idx_fields_assoc');
+
+        $this->assertSame(['title', 'sku'], $flatColumns);
+        $this->assertSame($assocColumns, $flatColumns);
+    }
+
+    public function test_flat_field_list_indexes_and_returns_documents(): void
+    {
+        $search = $this->createSearchInstance();
+        $search->createIndex('idx_fields_flat_search', ['fields' => ['title', 'sku']]);
+        $this->createdIndexes[] = 'idx_fields_flat_search';
+
+        $search->index('idx_fields_flat_search', [
+            'id' => 'p1',
+            'content' => ['title' => 'Blue Widget', 'sku' => 'ABC123'],
+        ]);
+
+        $results = $search->search('idx_fields_flat_search', 'Widget');
+
+        $this->assertGreaterThan(0, $results['total']);
+        $this->assertSame('p1', $results['results'][0]['id']);
+    }
+
+    public function test_mixed_flat_and_assoc_field_config_is_accepted(): void
+    {
+        $search = $this->createSearchInstance();
+        $search->createIndex('idx_fields_mixed', [
+            'fields' => ['title', 'sku' => ['boost' => 2.0]],
+        ]);
+        $this->createdIndexes[] = 'idx_fields_mixed';
+
+        $this->assertSame(['title', 'sku'], $this->ftsColumns($search, 'idx_fields_mixed'));
+    }
+
+    public function test_index_option_is_still_honoured_in_the_assoc_form(): void
+    {
+        $search = $this->createSearchInstance();
+        $search->createIndex('idx_fields_not_indexed', [
+            'fields' => [
+                'title' => ['boost' => 1.0],
+                'url' => ['boost' => 1.0, 'index' => false],
+            ],
+        ]);
+        $this->createdIndexes[] = 'idx_fields_not_indexed';
+
+        $this->assertSame(['title'], $this->ftsColumns($search, 'idx_fields_not_indexed'));
+    }
+
+    /**
+     * @dataProvider malformedFieldConfigs
+     */
+    public function test_malformed_field_config_throws(array $fields): void
+    {
+        $search = $this->createSearchInstance();
+
+        $this->expectException(InvalidArgumentException::class);
+        $search->createIndex('idx_fields_bad', ['fields' => $fields]);
+    }
+
+    public static function malformedFieldConfigs(): array
+    {
+        return [
+            'scalar field config' => [['title' => 'yes']],
+            'numeric field config' => [['title' => 3.0]],
+            'null field config' => [['title' => null]],
+            'non-string field name in list' => [[123]],
+            'array as field name in list' => [[['title']]],
+            'empty field name in list' => [['']],
+            'whitespace field name in list' => [['   ']],
+            'empty assoc field name' => [['' => ['boost' => 1.0]]],
+        ];
+    }
+
+    public function test_field_names_must_be_valid_identifiers(): void
+    {
+        $search = $this->createSearchInstance();
+
+        $this->expectException(InvalidArgumentException::class);
+        $search->createIndex('idx_fields_bad_name', ['fields' => ['title', 'drop table']]);
+    }
+}

--- a/tests/Integration/Search/SpecialCharacterQueryTest.php
+++ b/tests/Integration/Search/SpecialCharacterQueryTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace YetiSearch\Tests\Integration\Search;
+
+use YetiSearch\Tests\TestCase;
+
+/**
+ * Queries typed by end users routinely contain characters that are operators in
+ * the FTS5 MATCH grammar (hyphens in order numbers and SKUs, quotes, colons,
+ * asterisks, parentheses). None of them may reach MATCH unescaped.
+ */
+class SpecialCharacterQueryTest extends TestCase
+{
+    private const INDEX = 'idx_special_chars';
+
+    private function seedIndex(): \YetiSearch\YetiSearch
+    {
+        $search = $this->createSearchInstance();
+        $this->createTestIndex(self::INDEX);
+
+        $search->index(self::INDEX, [
+            'id' => 'order-1',
+            'content' => [
+                'title' => 'Order BENCH-100821',
+                'content' => 'Shipped order BENCH-100821 containing one widget.',
+            ],
+        ]);
+        $search->index(self::INDEX, [
+            'id' => 'product-1',
+            'content' => [
+                'title' => 'Blue Widget',
+                'content' => 'Catalog item with SKU ABC-123 and a state-of-the-art finish.',
+            ],
+        ]);
+
+        return $search;
+    }
+
+    public function test_hyphenated_order_number_returns_the_matching_document(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'BENCH-100821');
+
+        $this->assertGreaterThan(0, $results['total']);
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('order-1', $ids);
+    }
+
+    public function test_hyphenated_sku_returns_the_matching_document(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'ABC-123');
+
+        $this->assertGreaterThan(0, $results['total']);
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('product-1', $ids);
+    }
+
+    public function test_hyphenated_word_returns_the_matching_document(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'state-of-the-art');
+
+        $this->assertGreaterThan(0, $results['total']);
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('product-1', $ids);
+    }
+
+    /**
+     * @dataProvider specialCharacterQueries
+     */
+    public function test_special_character_queries_never_throw(string $query): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, $query);
+
+        $this->assertIsArray($results);
+        $this->assertArrayHasKey('results', $results);
+        $this->assertIsArray($results['results']);
+    }
+
+    public static function specialCharacterQueries(): array
+    {
+        return [
+            'hyphen' => ['BENCH-100821'],
+            'hyphen then digits' => ['ABC-123'],
+            'hyphen then letters' => ['foo-bar'],
+            'leading hyphen' => ['-100821'],
+            'trailing hyphen' => ['widget-'],
+            'double hyphen' => ['foo--bar'],
+            'apostrophe' => ["widget's"],
+            'double quote' => ['say "widget"'],
+            'unbalanced quote' => ['widget"'],
+            'asterisk' => ['widget*'],
+            'colon' => ['title:widget'],
+            'parentheses' => ['(widget)'],
+            'caret' => ['^widget'],
+            'plus' => ['widget+order'],
+            'comma' => ['widget,order'],
+            'braces' => ['{widget}'],
+            'bare NEAR' => ['NEAR'],
+            'bare AND' => ['AND'],
+            'bare OR' => ['OR'],
+            'bare NOT' => ['NOT'],
+            'NEAR expression' => ['NEAR(widget order, 2)'],
+            'AND expression' => ['widget AND order'],
+            'OR expression' => ['widget OR order'],
+            'NOT expression' => ['widget NOT order'],
+            'stray operators' => ['AND OR NOT NEAR'],
+            'mixed punctuation' => ['BENCH-100821: "widget" (x2)*'],
+            'only punctuation' => ['---'],
+        ];
+    }
+
+    public function test_hyphenated_query_works_with_fuzzy_enabled(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'BENCH-100821', ['fuzzy' => true]);
+
+        $this->assertIsArray($results['results']);
+    }
+
+    public function test_hyphenated_query_works_with_prefix_last_token(): void
+    {
+        $search = $this->createSearchInstance([
+            'search' => ['prefix_last_token' => true],
+        ]);
+        $this->createTestIndex(self::INDEX);
+        $search->index(self::INDEX, [
+            'id' => 'order-1',
+            'content' => ['title' => 'Order BENCH-100821', 'content' => 'A widget order.'],
+        ]);
+
+        $results = $search->search(self::INDEX, 'BENCH-100821');
+
+        $this->assertIsArray($results['results']);
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('order-1', $ids);
+    }
+
+    public function test_engine_count_accepts_hyphenated_queries(): void
+    {
+        $search = $this->seedIndex();
+
+        $engine = $search->getSearchEngine(self::INDEX);
+        $count = $engine->count(new \YetiSearch\Models\SearchQuery('BENCH-100821'));
+
+        $this->assertGreaterThan(0, $count);
+    }
+}


### PR DESCRIPTION
Three fixes found while integrating 2.3.1 against a 250k-document index. Each is a separate commit with tests.

## Escape user terms for FTS5 MATCH (#30)

Only bare alphanumeric runs are legal unquoted in the FTS5 `MATCH` grammar. Everything else is an operator there, so `search('orders', 'BENCH-100821')` was parsed as a column filter and SQLite rejected it with `no such column: 100821`. Any user-typed order number, SKU or hyphenated word threw a `StorageException` rather than returning results — from both `SqliteStorage::search()` and `SqliteStorage::count()`.

`SearchEngine::escapeFtsToken()` now wraps any term that is not a bare alphanumeric run, and any term colliding with the `AND`/`OR`/`NOT`/`NEAR` keywords, in double quotes. FTS5 then treats it as a literal phrase and re-tokenizes it with the table's own tokenizer, so `BENCH-100821` matches the indexed document as before. A trailing asterisk from `prefix_last_token` is kept outside the quotes so it stays a prefix operator, and inside a caller-assembled phrase only the quote character is doubled.

The escaping is applied per term, so the operators `processQuery()` builds around them — `OR`, `NEAR()`, phrase grouping — are untouched, and the intentional DSL and advanced-query paths behave exactly as before.

Covered by `tests/Integration/Search/SpecialCharacterQueryTest.php`: hyphens in several positions, digits after a hyphen, quotes, `*`, `:`, parentheses, caret, braces, commas, bare and expression-form `NEAR`/`AND`/`OR`/`NOT`, a punctuation-only query, plus the fuzzy, `prefix_last_token` and `count()` paths.

## Normalize and validate the indexer's fields option (#31)

`createIndex('products', ['fields' => ['title', 'sku']])` — a flat list rather than the documented associative map — was accepted without complaint and then iterated as if it were associative, so the integer list keys became the FTS column names. `insertBatch()`'s identifier sanitizer rejected them and fell back to a single `content` column, after which inserts either failed with `table X_fts has no column named content` or silently indexed nothing.

The `fields` option is now normalized in the `Indexer` constructor, before `ensureIndexExists()` sees it. A flat list is accepted as shorthand for the default boost, the documented associative form passes through, and the two may be mixed. Anything else — a scalar where a config array belongs, a non-string field name — throws `InvalidArgumentException` instead of corrupting the index. Field names become FTS5 column names, so they are also checked against the plain SQL identifier pattern rather than being interpolated unchecked.

Covered by `tests/Integration/Indexer/FieldsConfigNormalizationTest.php`, which asserts the flat and associative forms produce identical FTS column sets, that the flat form indexes and returns documents, that `index => false` is still honoured, and that each malformed shape throws.

## Restore the yetidevworks/yetisearch package name (#32)

The package was renamed to `yetisearch/yetisearch` in eea10cd, but the canonical package on Packagist is `yetidevworks/yetisearch`; `yetisearch/yetisearch` 404s and has never existed. The README badges and install instructions all still point at `yetidevworks`, so the rename only stood to break the next release sync. `composer.lock`'s content-hash is refreshed to match — no dependencies moved.

## Verification

Full suite goes from 484 tests / 1380 assertions to 530 tests / 1486 assertions, all passing, with no pre-existing failures to note. `phpstan analyse` (level 2) reports no errors, unchanged from the baseline. `phpcs --standard=PSR12` on the changed files is identical to the baseline — the new `Indexer` code is clean, and the pre-existing violations in `SearchEngine.php` are left as they were.

The CHANGELOG is untouched: its format has no Unreleased section, and no version heading should move before you cut a tag.

Closes #30
Closes #31
Closes #32