### PR TITLE
Fix stale FTS5 terms on external-content deletes and remaining query-operand leaks

### DIFF
--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -123,6 +123,16 @@ class SearchEngine implements SearchEngineInterface
             $originalQuery = $query->getQuery();
 
             $processedQuery = $this->processQuery($query);
+
+            if ($this->isTermlessQuery($query, $processedQuery)) {
+                $this->logger->debug('Query holds no searchable term', ['query' => $originalQuery]);
+
+                $emptyResults = new SearchResults([], 0, microtime(true) - $startTime);
+                $this->cacheResults($cacheKey, $emptyResults);
+
+                return $emptyResults;
+            }
+
             $storageQuery = $this->buildStorageQuery($processedQuery);
 
             // If deduplicating, we need to get ALL results first
@@ -351,6 +361,11 @@ class SearchEngine implements SearchEngineInterface
     public function count(SearchQuery $query): int
     {
         $processedQuery = $this->processQuery($query);
+
+        if ($this->isTermlessQuery($query, $processedQuery)) {
+            return 0;
+        }
+
         $storageQuery = $this->buildStorageQuery($processedQuery);
 
         return $this->storage->count($this->indexName, $storageQuery);
@@ -439,6 +454,47 @@ class SearchEngine implements SearchEngineInterface
         }
 
         return (bool)preg_match('/^[\p{L}\p{N}]+$/u', $token);
+    }
+
+    /**
+     * Escape a list of user terms, dropping any that escape to nothing.
+     *
+     * A token can escape to an empty string: it was empty to begin with, or it
+     * was nothing but the prefix operator. Left in the list it gets joined into
+     * the MATCH expression as a bare operand — "widget OR ", "NEAR(widget , 10)"
+     * — which FTS5 rejects with a syntax error.
+     *
+     * @param array<int, string> $tokens
+     * @return array<int, string>
+     */
+    private function escapeFtsTokens(array $tokens, bool $inPhrase = false): array
+    {
+        $escaped = [];
+
+        foreach ($tokens as $token) {
+            $value = $this->escapeFtsToken($token, $inPhrase);
+            if ($value !== '') {
+                $escaped[] = $value;
+            }
+        }
+
+        return $escaped;
+    }
+
+    /**
+     * True when the caller supplied query text that analysis reduced to nothing.
+     *
+     * An explicitly blank query means "no text query": geo-only and facet-only
+     * searches are expressed that way, and storage answers them with a match-all
+     * over whatever filters came with them. Text the user actually typed is a
+     * different thing. If none of it survives as a searchable term — punctuation,
+     * stray operators, stop words — the honest answer is no matches. Falling
+     * through to the match-all branch instead answers a search box full of
+     * punctuation with the entire index.
+     */
+    private function isTermlessQuery(SearchQuery $original, SearchQuery $processed): bool
+    {
+        return trim($original->getQuery()) !== '' && trim($processed->getQuery()) === '';
     }
 
     private function processQuery(SearchQuery $query): SearchQuery
@@ -599,17 +655,10 @@ class SearchEngine implements SearchEngineInterface
         if ($query->isFuzzy() && $useCorrectionMode && $this->config['enable_fuzzy']) {
             // Build a simple query with corrected terms
             // Use the same logic as non-fuzzy search but with corrected tokens
-            $escapedTokens = array_map(function ($t) {
-                return $this->escapeFtsToken($t, false);
-            }, $exactTokens);
+            $escapedTokens = $this->escapeFtsTokens($exactTokens);
 
-            if (count($exactTokens) > 1) {
-                // Multiple terms - search for all of them (implicit AND in FTS5)
-                $processedQuery = implode(' ', $escapedTokens);
-            } else {
-                // Single term
-                $processedQuery = $escapedTokens[0] ?? '';
-            }
+            // Multiple terms - search for all of them (implicit AND in FTS5)
+            $processedQuery = implode(' ', $escapedTokens);
         } elseif ($query->isFuzzy() && !$useCorrectionMode && !empty($fuzzyTokens)) {
             // Build structured query that strongly prioritizes exact matches
             // Use parentheses to group exact matches with higher priority
@@ -623,17 +672,15 @@ class SearchEngine implements SearchEngineInterface
             $exactComponents = [];
             if (count($tokens) > 1) {
                 // Escape tokens for FTS phrase
-                $escapedTokens = array_map(function ($t) {
-                    return $this->escapeFtsToken($t, true);
-                }, $tokens);
+                $escapedTokens = $this->escapeFtsTokens($tokens, true);
                 // Exact phrase gets highest priority
-                $exactComponents[] = '"' . implode(' ', $escapedTokens) . '"';
+                if (!empty($escapedTokens)) {
+                    $exactComponents[] = '"' . implode(' ', $escapedTokens) . '"';
+                }
             }
 
             // Escape exact tokens for FTS (as bare terms)
-            $escapedExactTokens = array_map(function ($t) {
-                return $this->escapeFtsToken($t, false);
-            }, $exactTokens);
+            $escapedExactTokens = $this->escapeFtsTokens($exactTokens);
 
             // Add individual exact tokens with NEAR proximity (if multiple tokens)
             if (count($escapedExactTokens) > 1) {
@@ -647,9 +694,7 @@ class SearchEngine implements SearchEngineInterface
             }
 
             // Build fuzzy component - group them with lower priority
-            $escapedFuzzyTokens = array_map(function ($t) {
-                return $this->escapeFtsToken($t, false);
-            }, $fuzzyTokens);
+            $escapedFuzzyTokens = $this->escapeFtsTokens($fuzzyTokens);
             $fuzzyComponent = count($escapedFuzzyTokens) > 0 ? '(' . implode(' OR ', $escapedFuzzyTokens) . ')' : '';
 
             // Combine with exact matches having priority
@@ -670,23 +715,23 @@ class SearchEngine implements SearchEngineInterface
             }
 
             $exactComponents = [];
+            $escapedExactTokens = $this->escapeFtsTokens($exactTokens);
             if (count($tokens) > 1) {
                 // Escape tokens for FTS phrase
-                $escapedTokens = array_map(function ($t) {
-                    return $this->escapeFtsToken($t, true);
-                }, $tokens);
-                $escapedExactTokens = array_map(function ($t) {
-                    return $this->escapeFtsToken($t, false);
-                }, $exactTokens);
+                $escapedTokens = $this->escapeFtsTokens($tokens, true);
 
                 // Add exact phrase
-                $exactComponents[] = '"' . implode(' ', $escapedTokens) . '"';
+                if (!empty($escapedTokens)) {
+                    $exactComponents[] = '"' . implode(' ', $escapedTokens) . '"';
+                }
                 // Add NEAR query for proximity boost
-                $exactComponents[] = 'NEAR(' . implode(' ', $escapedExactTokens) . ', 10)';
+                if (count($escapedExactTokens) > 1) {
+                    $exactComponents[] = 'NEAR(' . implode(' ', $escapedExactTokens) . ', 10)';
+                }
             }
             // Add individual tokens
-            foreach ($exactTokens as $token) {
-                $exactComponents[] = $this->escapeFtsToken($token, false);
+            foreach ($escapedExactTokens as $token) {
+                $exactComponents[] = $token;
             }
 
             $processedQuery = implode(' OR ', array_unique($exactComponents));

--- a/src/Storage/SqliteStorage.php
+++ b/src/Storage/SqliteStorage.php
@@ -402,7 +402,12 @@ class SqliteStorage implements StorageInterface
 
             $schema = $this->getSchemaMode($index);
             $docId = null;
+            $previousFtsRow = null;
             if ($schema === 'external') {
+                // Read what this document is currently indexed as before the
+                // upsert overwrites it; FTS5 needs that text to drop its terms.
+                $previousFtsRow = $this->getIndexedFtsRow($index, $id);
+
                 $upsertSql = "
                     INSERT INTO {$index} (id, content, metadata, language, type, timestamp)
                     VALUES (?, ?, ?, ?, ?, ?)
@@ -443,14 +448,11 @@ class SqliteStorage implements StorageInterface
                 $contentText = $this->getFieldText($document['content'], 'content', $index);
 
                 // For external content FTS5, we must explicitly delete the old entry
-                // before inserting the new one, otherwise old terms remain in the vocabulary.
-                // Use the special 'delete' command to remove old FTS entry for this rowid.
-                // We delete with empty content since the actual content doesn't matter for deletion.
-                try {
-                    $deleteFtsSql = "INSERT INTO {$index}_fts({$index}_fts, rowid, content) VALUES('delete', ?, ?)";
-                    $this->connection->prepare($deleteFtsSql)->execute([$docId, '']);
-                } catch (\PDOException $e) {
-                    // Ignore deletion errors (e.g., if entry doesn't exist)
+                // before inserting the new one, otherwise old terms remain in the
+                // vocabulary. The 'delete' command only removes the terms it is
+                // given, so it gets the text the row was actually indexed with.
+                if ($previousFtsRow !== null) {
+                    $this->deleteFtsRow($index, $previousFtsRow[0], $previousFtsRow[1]);
                 }
 
                 // Now insert the new FTS entry
@@ -535,11 +537,12 @@ class SqliteStorage implements StorageInterface
             // Prepare FTS insert statement dynamically
             $ftsColumns = $this->getFtsColumns($index);
             if ($schema === 'external') {
-                // External content with JSON storage only supports single-column FTS
-                // Note: For batch operations, we use INSERT OR REPLACE for performance.
-                // The FTS vocabulary may become stale on updates; use rebuildFts() after
-                // batch updates to resync the vocabulary with content.
-                $ftsStmt = $this->connection->prepare("INSERT OR REPLACE INTO {$index}_fts (rowid, content) VALUES (?, ?)");
+                // External content with JSON storage only supports single-column FTS.
+                // A plain INSERT, paired with an explicit 'delete' of whatever the
+                // rowid held before: INSERT OR REPLACE cannot remove the old terms,
+                // because by the time it looks them up the content table already
+                // holds the replacement text.
+                $ftsStmt = $this->connection->prepare("INSERT INTO {$index}_fts (rowid, content) VALUES (?, ?)");
             } else {
                 // Sanitize column names to ensure they're valid SQL identifiers
                 $validColumns = [];
@@ -574,6 +577,7 @@ class SqliteStorage implements StorageInterface
 
             // Collect FTS data for batch insert
             $ftsData = [];
+            $staleFtsRows = [];
             $termsData = [];
             $spatialDocs = [];
 
@@ -610,6 +614,17 @@ class SqliteStorage implements StorageInterface
                 $type = $document['type'] ?? 'default';
                 $timestamp = $document['timestamp'] ?? time();
 
+                // Read the text this document is currently indexed as, before the
+                // upsert overwrites it. Keyed by doc_id and only recorded once, so
+                // an id repeated inside one batch still deletes exactly the terms
+                // that were in the index when the batch started.
+                if ($schema === 'external') {
+                    $previousFtsRow = $this->getIndexedFtsRow($index, $id);
+                    if ($previousFtsRow !== null && !isset($staleFtsRows[$previousFtsRow[0]])) {
+                        $staleFtsRows[$previousFtsRow[0]] = $previousFtsRow;
+                    }
+                }
+
                 // Insert main document
                 $docStmt->execute([$id, $content, $metadata, $language, $type, $timestamp]);
 
@@ -623,7 +638,9 @@ class SqliteStorage implements StorageInterface
                         $docIdFallbackStmt->execute([$id]);
                         $docId = $docIdFallbackStmt->fetchColumn();
                     }
-                    $ftsData[] = [$docId, $this->getFieldText($document['content'], 'content', $index)];
+                    // Keyed by doc_id so a repeated id is inserted into FTS once,
+                    // with the last version of the document to appear in the batch.
+                    $ftsData[(int)$docId] = [$docId, $this->getFieldText($document['content'], 'content', $index)];
                 } else {
                     $values = [$id];
                     foreach ($ftsColumns as $col) {
@@ -639,6 +656,11 @@ class SqliteStorage implements StorageInterface
 
                 // Collect spatial data
                 $spatialDocs[] = [$id, $document];
+            }
+
+            // Drop the terms of every row being replaced before re-inserting it
+            foreach ($staleFtsRows as [$staleDocId, $staleText]) {
+                $this->deleteFtsRow($index, $staleDocId, $staleText);
             }
 
             // Batch insert FTS entries
@@ -715,27 +737,27 @@ class SqliteStorage implements StorageInterface
             // Capture doc_id early for external schema
             $schema = $this->getSchemaMode($index);
             $savedDocId = null;
+            $indexedFtsRow = null;
             if ($schema === 'external') {
-                $savedDocId = $this->getDocId($index, $id);
+                $indexedFtsRow = $this->getIndexedFtsRow($index, $id);
+                $savedDocId = $indexedFtsRow[0] ?? null;
+
+                // Drop the FTS entry before the content row goes. FTS5 has to be
+                // handed the text the row was indexed with, and the content table
+                // is the only place that text is kept — once the row is deleted it
+                // cannot be reconstructed, and the terms stay in the vocabulary
+                // pointing at a doc_id SQLite will reuse.
+                if ($indexedFtsRow !== null) {
+                    $this->deleteFtsRow($index, $indexedFtsRow[0], $indexedFtsRow[1]);
+                }
             }
 
-            // Delete from main table first
+            // Delete from main table
             $this->connection->prepare("DELETE FROM {$index} WHERE id = ?")->execute([$id]);
 
-            // Handle FTS deletion based on schema
-            if ($schema === 'external') {
-                // For external content, use FTS5's targeted delete command
-                // instead of a full rebuild (O(1) vs O(N))
-                if ($savedDocId !== null) {
-                    try {
-                        $deleteFtsSql = "INSERT INTO {$index}_fts({$index}_fts, rowid, content) VALUES('delete', ?, ?)";
-                        $this->connection->prepare($deleteFtsSql)->execute([$savedDocId, '']);
-                    } catch (\PDOException $e) {
-                        // Ignore deletion errors (e.g., if entry doesn't exist)
-                    }
-                }
-            } else {
-                // For non-external content, regular DELETE works
+            // The external schema already dropped its FTS entry above, before the
+            // content row was removed. For non-external content, regular DELETE works.
+            if ($schema !== 'external') {
                 $this->connection->prepare("DELETE FROM {$index}_fts WHERE id = ?")->execute([$id]);
             }
 
@@ -798,13 +820,16 @@ class SqliteStorage implements StorageInterface
 
             $this->connection->beginTransaction();
 
-            // Collect spatial IDs BEFORE deleting from main table
+            // Collect spatial IDs and indexed FTS text BEFORE deleting from main
+            // table — once the content rows are gone the text cannot be recovered
             $spatialIds = [];
+            $indexedFtsRows = [];
             if ($schema === 'external') {
                 foreach ($ids as $id) {
-                    $docId = $this->getDocId($index, $id);
-                    if ($docId !== null) {
-                        $spatialIds[] = $docId;
+                    $indexedFtsRow = $this->getIndexedFtsRow($index, $id);
+                    if ($indexedFtsRow !== null) {
+                        $indexedFtsRows[] = $indexedFtsRow;
+                        $spatialIds[] = $indexedFtsRow[0];
                     }
                 }
             }
@@ -816,11 +841,16 @@ class SqliteStorage implements StorageInterface
 
             // Handle FTS deletion based on schema
             if ($schema === 'external') {
-                // For external content tables, optionally rebuild FTS to sync
                 if ($rebuildFts) {
+                    // A full rebuild resyncs the vocabulary in one pass
                     $this->connection->exec("INSERT INTO {$index}_fts({$index}_fts) VALUES('rebuild')");
+                } else {
+                    // Otherwise drop each row's terms individually, using the text
+                    // read before the content rows were deleted
+                    foreach ($indexedFtsRows as [$docId, $indexedText]) {
+                        $this->deleteFtsRow($index, $docId, $indexedText);
+                    }
                 }
-                // Note: If rebuildFts is false, caller must call rebuildFts() after all operations
             } else {
                 // For non-external content, delete matching rows
                 $this->connection->prepare("DELETE FROM {$index}_fts WHERE id IN ({$placeholders})")->execute($ids);
@@ -1725,6 +1755,57 @@ class SqliteStorage implements StorageInterface
             return (int)$val;
         } catch (\PDOException $e) {
             return null;
+        }
+    }
+
+    /**
+     * The doc_id and the exact text an external-content FTS5 row was indexed with.
+     *
+     * An FTS5 content= table keeps no copy of the text, so removing a row's terms
+     * means handing the original column values back to it. The content table is
+     * the only place they are kept, which is why this has to be read before the
+     * row is deleted or overwritten.
+     *
+     * @return array{0: int, 1: string}|null doc_id and indexed text, or null when
+     *                                       the document is not in the index
+     */
+    private function getIndexedFtsRow(string $index, string $id): ?array
+    {
+        try {
+            $stmt = $this->connection->prepare("SELECT doc_id, content FROM {$index} WHERE id = ?");
+            $stmt->execute([$id]);
+            $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        } catch (\PDOException $e) {
+            return null;
+        }
+
+        if (!is_array($row) || !isset($row['doc_id'])) {
+            return null;
+        }
+
+        $content = json_decode((string)($row['content'] ?? ''), true);
+
+        return [
+            (int)$row['doc_id'],
+            $this->getFieldText(is_array($content) ? $content : [], 'content', $index),
+        ];
+    }
+
+    /**
+     * Remove one external-content FTS5 row's terms from the vocabulary.
+     *
+     * The text must be what the row was indexed with. Passing anything else — an
+     * empty string, or the replacement text of a document being updated — deletes
+     * nothing, and the old terms stay in the index pointing at a doc_id SQLite is
+     * free to hand to the next document.
+     */
+    private function deleteFtsRow(string $index, int $docId, string $indexedText): void
+    {
+        try {
+            $sql = "INSERT INTO {$index}_fts({$index}_fts, rowid, content) VALUES('delete', ?, ?)";
+            $this->connection->prepare($sql)->execute([$docId, $indexedText]);
+        } catch (\PDOException $e) {
+            // The row was never in the FTS index, so there is nothing to remove.
         }
     }
 

--- a/tests/Integration/Search/SpecialCharacterQueryTest.php
+++ b/tests/Integration/Search/SpecialCharacterQueryTest.php
@@ -143,6 +143,131 @@ class SpecialCharacterQueryTest extends TestCase
         $this->assertContains('order-1', $ids);
     }
 
+    /**
+     * A colon is FTS5 column-filter syntax. The plain search() path has no
+     * column-filter feature — that is the DSL's job (`field = "value"`) — so
+     * "title:widget" is nothing but user text, and it must never restrict the
+     * match to the "title" column. Here "widget" lives only in the content
+     * field, so a column filter would return nothing.
+     */
+    public function test_field_prefix_text_does_not_filter_by_column(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'title:widget');
+
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('product-1', $ids);
+    }
+
+    public function test_field_prefix_text_with_an_unknown_column_still_searches(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'nosuchcolumn:widget');
+
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('product-1', $ids);
+    }
+
+    public function test_bare_field_prefix_returns_no_results_rather_than_everything(): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, 'foo:');
+
+        $this->assertSame(0, $results['total']);
+    }
+
+    /**
+     * A query the user actually typed that contains no searchable term at all
+     * must come back empty. Falling through to the unfiltered match-all branch
+     * answers a search box full of punctuation with the entire index.
+     *
+     * @dataProvider termlessQueries
+     */
+    public function test_queries_with_no_searchable_term_return_no_results(string $query): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, $query);
+
+        $this->assertSame(0, $results['total'], "Query {$query} should not match every document");
+        $this->assertSame([], $results['results']);
+    }
+
+    public static function termlessQueries(): array
+    {
+        return [
+            'colon' => [':'],
+            'ellipsis' => ['...'],
+            'hyphens' => ['---'],
+            'asterisk' => ['*'],
+            'double asterisk' => ['**'],
+            'quote' => ['"'],
+            'empty quotes' => ['""'],
+            'parentheses' => ['()'],
+            'caret' => ['^'],
+            'mixed punctuation' => ['!?.,;'],
+        ];
+    }
+
+    /**
+     * An empty (or whitespace-only) query is the caller saying "no text query",
+     * which is how geo-only and facet-only searches are expressed. That branch
+     * stays a match-all.
+     *
+     * @dataProvider blankQueries
+     */
+    public function test_a_blank_query_remains_a_match_all(string $query): void
+    {
+        $search = $this->seedIndex();
+
+        $results = $search->search(self::INDEX, $query);
+
+        $this->assertSame(2, $results['total']);
+    }
+
+    public static function blankQueries(): array
+    {
+        return [
+            'empty string' => [''],
+            'whitespace only' => ['   '],
+        ];
+    }
+
+    public function test_count_agrees_with_search_on_a_termless_query(): void
+    {
+        $search = $this->seedIndex();
+
+        $engine = $search->getSearchEngine(self::INDEX);
+
+        $this->assertSame(0, $engine->count(new \YetiSearch\Models\SearchQuery('...')));
+    }
+
+    /**
+     * With punctuation stripping turned off the raw token reaches the escaper,
+     * and a token that is nothing but the prefix operator used to collapse to
+     * an empty string that was then joined into the MATCH expression, producing
+     * "widget OR " and an fts5 syntax error.
+     */
+    public function test_operator_only_token_does_not_break_the_match_expression(): void
+    {
+        $search = $this->createSearchInstance([
+            'analyzer' => ['strip_punctuation' => false],
+        ]);
+        $this->createTestIndex(self::INDEX);
+        $search->index(self::INDEX, [
+            'id' => 'product-1',
+            'content' => ['title' => 'Blue Widget', 'content' => 'A widget.'],
+        ]);
+
+        $results = $search->search(self::INDEX, 'widget *');
+
+        $ids = array_column($results['results'], 'id');
+        $this->assertContains('product-1', $ids);
+    }
+
     public function test_engine_count_accepts_hyphenated_queries(): void
     {
         $search = $this->seedIndex();

--- a/tests/Integration/Storage/ExternalContentFtsDeleteTest.php
+++ b/tests/Integration/Storage/ExternalContentFtsDeleteTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace YetiSearch\Tests\Integration\Storage;
+
+use YetiSearch\Tests\TestCase;
+use YetiSearch\YetiSearch;
+
+/**
+ * External content is the default storage mode, and its FTS5 table holds no
+ * copy of the indexed text — SQLite needs the original column values handed
+ * back to it to remove a row's terms from the vocabulary. Deleting or replacing
+ * a document without them leaves the old terms behind, pointing at a doc_id
+ * that SQLite is then free to hand to the next document (doc_id is a plain
+ * INTEGER PRIMARY KEY, so rowids are reused).
+ */
+class ExternalContentFtsDeleteTest extends TestCase
+{
+    private const INDEX = 'idx_external_delete';
+
+    private function createExternalIndex(): YetiSearch
+    {
+        $search = $this->createSearchInstance([
+            'storage' => ['external_content' => true],
+        ]);
+        $this->createTestIndex(self::INDEX);
+
+        return $search;
+    }
+
+    private function ids(array $results): array
+    {
+        return array_column($results['results'], 'id');
+    }
+
+    public function test_a_deleted_documents_terms_stop_matching(): void
+    {
+        $search = $this->createExternalIndex();
+
+        $search->index(self::INDEX, [
+            'id' => 'x',
+            'content' => ['title' => 'Zarquon Widget', 'content' => 'The zarquon is a rare thing.'],
+        ]);
+        $search->delete(self::INDEX, 'x');
+
+        $results = $search->search(self::INDEX, 'zarquon');
+
+        $this->assertSame(0, $results['total']);
+    }
+
+    /**
+     * The regression proper: delete a document, then index a new one that takes
+     * over the freed doc_id. The new document must not answer for the old one's
+     * words, and must still be findable by its own.
+     */
+    public function test_a_reused_doc_id_does_not_inherit_the_deleted_documents_terms(): void
+    {
+        $search = $this->createExternalIndex();
+
+        $search->index(self::INDEX, [
+            'id' => 'x',
+            'content' => ['title' => 'Zarquon Widget', 'content' => 'The zarquon is a rare thing.'],
+        ]);
+        $search->delete(self::INDEX, 'x');
+        $search->index(self::INDEX, [
+            'id' => 'y',
+            'content' => ['title' => 'Ordinary Sprocket', 'content' => 'Nothing rare about this one.'],
+        ]);
+
+        $this->assertSame(
+            [],
+            $this->ids($search->search(self::INDEX, 'zarquon')),
+            'The new document inherited the deleted document\'s terms'
+        );
+        $this->assertContains('y', $this->ids($search->search(self::INDEX, 'sprocket')));
+    }
+
+    public function test_an_updated_document_stops_matching_its_old_text(): void
+    {
+        $search = $this->createExternalIndex();
+
+        $search->index(self::INDEX, [
+            'id' => 'u',
+            'content' => ['title' => 'Flibbertigibbet', 'content' => 'The original flibbertigibbet text.'],
+        ]);
+        $search->index(self::INDEX, [
+            'id' => 'u',
+            'content' => ['title' => 'Renamed', 'content' => 'Replacement text entirely.'],
+        ]);
+
+        $this->assertSame(
+            [],
+            $this->ids($search->search(self::INDEX, 'flibbertigibbet')),
+            'The updated document still matches its replaced text'
+        );
+        $this->assertContains('u', $this->ids($search->search(self::INDEX, 'replacement')));
+    }
+
+    public function test_a_batch_updated_document_stops_matching_its_old_text(): void
+    {
+        $search = $this->createExternalIndex();
+
+        $search->indexBatch(self::INDEX, [
+            ['id' => 'z', 'content' => ['title' => 'Snorkwaffle', 'content' => 'The first snorkwaffle.']],
+        ]);
+        $search->getIndexer(self::INDEX)->flush();
+        $search->indexBatch(self::INDEX, [
+            ['id' => 'z', 'content' => ['title' => 'Batched Again', 'content' => 'Wholly different wording.']],
+        ]);
+        $search->getIndexer(self::INDEX)->flush();
+
+        $this->assertSame(
+            [],
+            $this->ids($search->search(self::INDEX, 'snorkwaffle')),
+            'The batch-updated document still matches its replaced text'
+        );
+        $this->assertContains('z', $this->ids($search->search(self::INDEX, 'wording')));
+    }
+
+    /**
+     * deleteByIdPrefix() with $rebuildFts = false leaves the caller responsible
+     * for resyncing, but the targeted deletes it does perform must be correct on
+     * their own so that a following insert cannot inherit anything.
+     */
+    public function test_delete_by_prefix_removes_the_deleted_documents_terms(): void
+    {
+        $search = $this->createExternalIndex();
+
+        $search->index(self::INDEX, [
+            'id' => 'page#chunk1',
+            'content' => ['title' => 'Chunk One', 'content' => 'Contains the word grimbleshanks.'],
+        ]);
+        $search->index(self::INDEX, [
+            'id' => 'page#chunk2',
+            'content' => ['title' => 'Chunk Two', 'content' => 'Contains the word wibbleflop.'],
+        ]);
+
+        $storage = new \ReflectionClass($search);
+        $method = $storage->getMethod('getStorage');
+        $method->setAccessible(true);
+        /** @var \YetiSearch\Storage\SqliteStorage $sqlite */
+        $sqlite = $method->invoke($search);
+        $sqlite->deleteByIdPrefix(self::INDEX, 'page#chunk', false);
+
+        $this->assertSame(0, $search->search(self::INDEX, 'grimbleshanks')['total']);
+        $this->assertSame(0, $search->search(self::INDEX, 'wibbleflop')['total']);
+    }
+
+    /**
+     * The FTS5 vocabulary itself must be clean, not merely masked by the join
+     * back to the content table.
+     */
+    public function test_the_fts_vocabulary_no_longer_holds_the_deleted_term(): void
+    {
+        $search = $this->createExternalIndex();
+
+        $search->index(self::INDEX, [
+            'id' => 'x',
+            'content' => ['title' => 'Zarquon', 'content' => 'zarquon'],
+        ]);
+        $search->delete(self::INDEX, 'x');
+
+        $reflection = new \ReflectionClass($search);
+        $method = $reflection->getMethod('getStorage');
+        $method->setAccessible(true);
+        /** @var \YetiSearch\Storage\SqliteStorage $sqlite */
+        $sqlite = $method->invoke($search);
+
+        $connection = new \ReflectionProperty(\YetiSearch\Storage\SqliteStorage::class, 'connection');
+        $connection->setAccessible(true);
+        /** @var \PDO $pdo */
+        $pdo = $connection->getValue($sqlite);
+
+        $index = self::INDEX;
+        $pdo->exec("CREATE VIRTUAL TABLE IF NOT EXISTS {$index}_vocab USING fts5vocab('{$index}_fts', 'row')");
+        $stmt = $pdo->prepare("SELECT cnt FROM {$index}_vocab WHERE term = ?");
+        $stmt->execute(['zarquon']);
+        $count = $stmt->fetchColumn();
+
+        $this->assertFalse($count !== false && (int)$count > 0, 'Deleted term is still in the FTS vocabulary');
+    }
+}


### PR DESCRIPTION
Two correctness bugs found integrating 2.3.2 into a storefront. Each one is a failing test first, then the fix.

Closes #34
Closes #35

## Stale FTS5 terms on external-content deletes

An FTS5 `content=` table stores no copy of the indexed text, so its `'delete'` command removes exactly the terms it is handed and nothing else. Every delete site passed an empty string instead, which deletes nothing. The old terms stayed in the vocabulary pointing at a `doc_id` — and `doc_id` is a plain `INTEGER PRIMARY KEY`, so SQLite hands that rowid straight to the next document inserted, which then answers for words only the deleted one ever contained. `delete()` compounded it by removing the content row before the FTS delete ran, leaving nothing to reconstruct the text from even in principle.

Every path now reads the `doc_id` and the text the row was indexed with — through the same `getFieldText()` extraction the insert used — before anything is overwritten, and hands that text to the `'delete'` command:

- `delete()` reads it before the content row is removed, and drops the FTS entry first.
- `insert()` (which `update()` and the upsert path go through) reads it before the upsert overwrites the content column.
- `insertBatch()` does the same per document, keyed by `doc_id` so an id repeated inside one batch still deletes exactly what was in the index when the batch started. It no longer uses `INSERT OR REPLACE`, which cannot work here: by the time it looks up the terms to remove, the content table already holds the replacement text. That is what the "vocabulary may become stale" note at SqliteStorage.php ~540 was describing.
- `deleteByIdPrefix($rebuildFts: false)` now issues targeted deletes rather than leaving the vocabulary for the caller to resync.

Two new private helpers carry it: `getIndexedFtsRow()` and `deleteFtsRow()`.

The practical effect is that callers no longer need a `rebuildFts()` after every write batch to keep results correct — an O(index) operation that was standing in for an O(1) one.

`tests/Integration/Storage/ExternalContentFtsDeleteTest.php` covers the delete-then-reuse regression, the update and batch-update variants, `deleteByIdPrefix()`, and one assertion straight against the `fts5vocab` table so the vocabulary itself is checked rather than the join back to the content table. Four of its six tests fail on main.

I also checked the upgrade path — a database written by 2.3.2 keeps working, and FTS5's own `integrity-check` (rank 0) stays clean through delete, reuse and batch update.

## Remaining query-operand leaks

`escapeFtsToken()` returns an empty string for a token that is empty or is nothing but the prefix operator, and every caller mapped the escaper over its tokens and joined the result — so the empty string was joined into the MATCH expression as a bare operand. `widget *` built `widget OR ` and SQLite answered with `fts5: syntax error near ""`. Escaping now goes through `escapeFtsTokens()`, which drops the empties, and the phrase and `NEAR()` components are only emitted while they still have operands.

Separately, a query that reduces to no searchable term — `:`, `...`, `**`, `()` — left the processed query empty, and an empty query is how storage is told to match everything. A search box full of punctuation therefore answered with the whole index, and `count()` reported the same inflated number. `search()` and `count()` now return no results for text that yields no term.

An explicitly blank query is deliberately left alone: that is how a caller says "no text query", which is the only way to express a geo-only or facet-only search, and it still matches all documents subject to its filters. The distinction is drawn in `isTermlessQuery()`.

The plain `search()` path has no column-filter syntax — reaching a column filter is the DSL's job via `field = "value"` — so `title:widget` there is literal user text. That already held, and there are now tests pinning it so it stays that way.

`tests/Integration/Search/SpecialCharacterQueryTest.php` gains the field-prefix cases, the termless cases, the blank-query match-all guard, a `count()`/`search()` agreement check, and the operator-only token. Ten failures and one fts5 syntax error on main.

## Checks

- `vendor/bin/phpunit`: 530 tests on main, 553 here, all green.
- `vendor/bin/phpstan analyse`: no errors, same as main.

## Not in this PR

`YetiSearch::multiSearch()` / `searchMultiple()` hand the raw query string to `SqliteStorage::searchMultiple()` without going through `SearchEngine` at all, so none of the escaping applies to them. `multiSearch(['t'], 'BENCH-100821')` returns no results rather than the matching document: the fts5 error is raised per index and swallowed by the `continue` in that method's catch block. That is a structural gap rather than a leak in the escaping, and it wants its own change.
